### PR TITLE
Improve test compatibility with node.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ const Server = exports.Server = class TCPServer extends EventEmitter {
 
   listen (port = 0, host = '0.0.0.0', backlog = 511, opts = {}, onlistening) {
     if (this._state & constants.state.LISTENING) {
-      throw errors.SERVER_ALREADY_LISTEN('Server is already listening')
+      throw errors.SERVER_ALREADY_LISTENING('Server is already listening')
     }
 
     if (this._state & constants.state.CLOSING) {

--- a/index.js
+++ b/index.js
@@ -253,6 +253,10 @@ const Server = exports.Server = class TCPServer extends EventEmitter {
   }
 
   listen (port = 0, host = '0.0.0.0', backlog = 511, opts = {}, onlistening) {
+    if (this._state & constants.state.LISTENING) {
+      throw errors.SERVER_ALREADY_LISTEN('Server is already listening')
+    }
+
     if (this._state & constants.state.CLOSING) {
       throw errors.SERVER_IS_CLOSED('Server is closed')
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,6 +12,10 @@ module.exports = class TCPError extends Error {
     return 'TCPError'
   }
 
+  static SERVER_ALREADY_LISTEN (msg) {
+    return new TCPError(msg, 'SERVER_ALREADY_LISTEN', TCPError.SERVER_ALREADY_CLOSED)
+  }
+
   static SERVER_IS_CLOSED (msg) {
     return new TCPError(msg, 'SERVER_IS_CLOSED', TCPError.SERVER_IS_CLOSED)
   }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,8 +12,8 @@ module.exports = class TCPError extends Error {
     return 'TCPError'
   }
 
-  static SERVER_ALREADY_LISTEN (msg) {
-    return new TCPError(msg, 'SERVER_ALREADY_LISTEN', TCPError.SERVER_ALREADY_CLOSED)
+  static SERVER_ALREADY_LISTENING (msg) {
+    return new TCPError(msg, 'SERVER_ALREADY_LISTENING', TCPError.SERVER_ALREADY_LISTENING)
   }
 
   static SERVER_IS_CLOSED (msg) {

--- a/test.js
+++ b/test.js
@@ -78,7 +78,7 @@ test('not accept server calling listen method twice', async (t) => {
   try {
     server.listen(port)
   } catch (err) {
-    t.ok(err.code?.includes('SERVER_ALREADY_LISTEN'))
+    t.is(err.code, 'SERVER_ALREADY_LISTENING')
     server.close()
   }
 })
@@ -125,12 +125,12 @@ test('server.listen arguments', (t) => {
     server2.close()
   })
 
-  const server3 = createServer().listen(60000, () => {
+  const server3 = createServer().listen(0, () => {
     args.pass('port and listener')
     server3.close()
   })
 
-  const server4 = createServer().listen(60001, '0.0.0.0', () => {
+  const server4 = createServer().listen(0, '0.0.0.0', () => {
     args.pass('port, host and listener')
     server4.close()
   })

--- a/test.js
+++ b/test.js
@@ -75,19 +75,20 @@ test('not accept server binding when closing', (t) => {
   t.exception(() => server.listen(), /Server is closed/)
 })
 
-test('not accept server binding when already bound', async (t) => {
+test('not accept server calling listen method twice', async (t) => {
   t.plan(1)
 
   const server = createServer().listen()
   await waitForServer(server)
 
   const { port } = server.address()
-  server.listen(port)
-  server.on('error', (err) => {
-    t.is(err.code, 'EINVAL')
 
+  try {
+    server.listen(port)
+  } catch (err) {
+    t.ok(err.code?.includes('SERVER_ALREADY_LISTEN'))
     server.close()
-  })
+  }
 })
 
 test('createConnection arguments', async (t) => {

--- a/test.js
+++ b/test.js
@@ -66,15 +66,6 @@ test('not accept address request when not listening', (t) => {
   t.is(server.address(), null)
 })
 
-test('not accept server binding when closing', (t) => {
-  t.plan(1)
-
-  const server = createServer()
-
-  server.close()
-  t.exception(() => server.listen(), /Server is closed/)
-})
-
 test('not accept server calling listen method twice', async (t) => {
   t.plan(1)
 

--- a/test.js
+++ b/test.js
@@ -125,12 +125,12 @@ test('server.listen arguments', (t) => {
     server2.close()
   })
 
-  const server3 = createServer().listen(99234, () => {
+  const server3 = createServer().listen(60000, () => {
     args.pass('port and listener')
     server3.close()
   })
 
-  const server4 = createServer().listen(99235, '0.0.0.0', () => {
+  const server4 = createServer().listen(60001, '0.0.0.0', () => {
     args.pass('port, host and listener')
     server4.close()
   })

--- a/test.js
+++ b/test.js
@@ -42,6 +42,7 @@ test('socket state getters', async (t) => {
   socket.connect(server.address().port)
   t.is(socket.connecting, true, 'connecting')
 
+  socket.destroy()
   server.close()
 })
 
@@ -93,8 +94,16 @@ test('createConnection arguments', async (t) => {
   await waitForServer(server)
 
   const { port } = server.address()
-  createConnection(port, () => args.pass('port and listener')).end()
-  createConnection(port, 'localhost', () => args.pass('port, host and listener')).end()
+
+  const socket1 = createConnection(port, () => {
+    args.pass('port and listener')
+    socket1.destroy()
+  })
+
+  const socket2 = createConnection(port, 'localhost', () => {
+    args.pass('port, host and listener')
+    socket2.destroy()
+  })
 
   await args
 


### PR DESCRIPTION
All commits were made thinking of node.js compatibility, the changes are:

- The going back of `SERVER_ALREADY_LISTEN` error.
- Better test lifecycle at destroying some sockets manually.
- Removal of `not accept server binding when closing` test, motivated by Mathias's feedback.