### PR TITLE
Add IPv6 support

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -19,4 +19,8 @@ module.exports = class TCPError extends Error {
   static SERVER_IS_CLOSED (msg) {
     return new TCPError(msg, 'SERVER_IS_CLOSED', TCPError.SERVER_IS_CLOSED)
   }
+
+  static INVALID_HOST (msg = 'Unrecognizable host format') {
+    return new TCPError(msg, 'INVALID_HOST', TCPError.INVALID_HOST)
+  }
 }

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1,0 +1,50 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const v4Seg = '(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+const v4Str = `(${v4Seg}[.]){3}${v4Seg}`
+const IPv4Pattern = new RegExp(`^${v4Str}$`)
+
+const v6Seg = '(?:[0-9a-fA-F]{1,4})'
+const IPv6Pattern = new RegExp('^(' +
+  `(?:${v6Seg}:){7}(?:${v6Seg}|:)|` +
+  `(?:${v6Seg}:){6}(?:${v4Str}|:${v6Seg}|:)|` +
+  `(?:${v6Seg}:){5}(?::${v4Str}|(:${v6Seg}){1,2}|:)|` +
+  `(?:${v6Seg}:){4}(?:(:${v6Seg}){0,1}:${v4Str}|(:${v6Seg}){1,3}|:)|` +
+  `(?:${v6Seg}:){3}(?:(:${v6Seg}){0,2}:${v4Str}|(:${v6Seg}){1,4}|:)|` +
+  `(?:${v6Seg}:){2}(?:(:${v6Seg}){0,3}:${v4Str}|(:${v6Seg}){1,5}|:)|` +
+  `(?:${v6Seg}:){1}(?:(:${v6Seg}){0,4}:${v4Str}|(:${v6Seg}){1,6}|:)|` +
+  `(?::((?::${v6Seg}){0,5}:${v4Str}|(?::${v6Seg}){1,7}|:))` +
+')(%[0-9a-zA-Z-.:]{1,})?$')
+
+const isIPv4 = exports.isIPv4 = function isIPv4 (host) {
+  return IPv4Pattern.test(host)
+}
+
+const isIPv6 = exports.isIPv6 = function isIPv6 (host) {
+  return IPv6Pattern.test(host)
+}
+
+exports.isIP = function isIP (host) {
+  if (isIPv4(host)) return 4
+  if (isIPv6(host)) return 6
+  return 0
+}

--- a/test.js
+++ b/test.js
@@ -136,6 +136,30 @@ test('server.listen arguments', (t) => {
   })
 })
 
+test('ipv6 support', async (t) => {
+  t.plan(2)
+
+  const server = createServer()
+    .on('connection', (socket) => {
+      socket
+        .on('data', (data) => {
+          t.is(data.toString(), 'hello ipv6', 'received message')
+
+          server.close()
+        })
+        .end()
+    })
+    .listen(0, '::')
+
+  await waitForServer(server)
+
+  const { port, family } = server.address()
+
+  t.is(family, 'IPv6', 'server family is \'IPv6\'')
+
+  createConnection({ port, family: 6 }).end('hello ipv6')
+})
+
 function waitForServer (server) {
   return new Promise((resolve, reject) => {
     server.on('listening', done)

--- a/test.js
+++ b/test.js
@@ -160,6 +160,11 @@ test('ipv6 support', async (t) => {
   createConnection({ port, family: 6 }).end('hello ipv6')
 })
 
+test('handle invalid host', (t) => {
+  const server = createServer()
+  t.exception(() => server.listen(0, '0000'), /INVALID_HOST/)
+})
+
 function waitForServer (server) {
   return new Promise((resolve, reject) => {
     server.on('listening', done)


### PR DESCRIPTION
Along with the feature implementation, there is a refactor about how we deal with multiple argument schemas, my goals were easy scalability/adaptation, and don't repeat the default values; as a downside, the code became a bit verbose.

About the IPv6 feature, I added a very simple heuristic to detect which family the host belongs: `const family = host.includes(':') ? 6 : 4`, and IDK if it's the recommended way or good enough.

The new unit test was tested on node.js as well. 