### PR TITLE
Add `timeout` feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const Socket = exports.Socket = class TCPSocket extends Duplex {
     this._pendingDestroy = null
 
     this._timer = null
+    this._timeout = 0
 
     this._buffer = Buffer.alloc(readBufferSize)
 
@@ -52,6 +53,10 @@ const Socket = exports.Socket = class TCPSocket extends Duplex {
 
   get pending () {
     return (this._state & constants.state.CONNECTED) === 0
+  }
+
+  get timeout () {
+    return this._timeout || undefined // For Node.js compatibility
   }
 
   connect (port, host = 'localhost', opts = {}, onconnect) {
@@ -156,8 +161,7 @@ const Socket = exports.Socket = class TCPSocket extends Duplex {
     if (ontimeout) this.once('timeout', ontimeout)
 
     this._timer = setTimeout(() => this.emit('timeout'), ms)
-
-    this.timeout = ms
+    this._timeout = ms
 
     return this
   }

--- a/index.js
+++ b/index.js
@@ -158,9 +158,14 @@ const Socket = exports.Socket = class TCPSocket extends Duplex {
   }
 
   setTimeout (ms, ontimeout) {
-    if (ontimeout) this.once('timeout', ontimeout)
+    if (ms === 0) {
+      clearTimeout(this._timer)
+      this._timer = null
+    } else {
+      if (ontimeout) this.once('timeout', ontimeout)
+      this._timer = setTimeout(() => this.emit('timeout'), ms)
+    }
 
-    this._timer = setTimeout(() => this.emit('timeout'), ms)
     this._timeout = ms
 
     return this

--- a/test.js
+++ b/test.js
@@ -197,45 +197,37 @@ test('timeout', (t) => {
     const sub = t.test()
     sub.plan(3)
 
-    const _sockets = []
-
-    const server = createServer((s) => _sockets.push(s)).listen()
+    const server = createServer((s) => s.end()).listen()
     await waitForServer(server)
 
     const socket = createConnection(server.address().port, () => {
       socket.setTimeout(10, () => sub.pass('timeout callback'))
       socket.on('timeout', () => sub.pass('timeout event'))
       sub.is(socket.timeout, 10)
-
-      _sockets.push(socket)
     })
 
     await sub
 
-    _sockets.forEach((s) => s.destroy())
+    socket.destroy()
     server.close()
   })
 
-  t.test('timeout option at createConnection', async (t) => {
+  t.test('timeout option', async (t) => {
     const sub = t.test()
     sub.plan(1)
 
-    const _sockets = []
-
-    const server = createServer((s) => _sockets.push(s)).listen()
+    const server = createServer((s) => s.end()).listen()
     await waitForServer(server)
 
     const { port } = server.address()
 
     const socket = createConnection({ port, timeout: 10 }, () => {
       socket.on('timeout', () => sub.pass('timeout triggered'))
-
-      _sockets.push(socket)
     })
 
     await sub
 
-    _sockets.forEach((s) => s.destroy())
+    socket.destroy()
     server.close()
   })
 


### PR DESCRIPTION
Following nodejs docs specification:

- socket.`timeout` informing the current timeout ms value.
- 'timeout' event, and optional callback at `setTimeout`
- timeout option at `createConnection`

---

I set to refresh the timeout at `_onread` and `_onwrite`.

---

One thing that I noticed that bare-tcp is behaving differently to nodejs in my experience is: the tests cannot be closed (the sample server keeps listening) if the `server connection socket` is not destroyed manually, that's why I am collecting it at lines like: `const server = createServer((s) => _sockets.push(s)).listen()`.