### PR TITLE
Unref socket timer at socket unref

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,8 @@ const Socket = exports.Socket = class TCPSocket extends Duplex {
 
   unref () {
     binding.unref(this._handle)
+
+    if (this._timer) this._timer.unref()
   }
 
   _open (cb) {

--- a/index.js
+++ b/index.js
@@ -163,7 +163,9 @@ const Socket = exports.Socket = class TCPSocket extends Duplex {
       this._timer = null
     } else {
       if (ontimeout) this.once('timeout', ontimeout)
+
       this._timer = setTimeout(() => this.emit('timeout'), ms)
+      this._timer.unref()
     }
 
     this._timeout = ms
@@ -177,8 +179,6 @@ const Socket = exports.Socket = class TCPSocket extends Duplex {
 
   unref () {
     binding.unref(this._handle)
-
-    if (this._timer) this._timer.unref()
   }
 
   _open (cb) {


### PR DESCRIPTION
Minor issue, the tests from `bare-http1` with default Agent enabled are kept hanged by the time of the agent's predefined timeout, although we call `socket.unref()` at `keepSocketAlive` function, the socket blocks the process closure because of it's timer.

This PR prevents a test of 15ms from taking about 5020ms, not sure if it's the right place for the fix.