### PR TITLE
Handle `binding.address()` failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,8 +388,17 @@ exports.Socket = class TCPSocket extends Duplex {
   }
 
   _onaccept() {
-    this._localAddress = binding.address(this._handle, true)
-    this._remoteAddress = binding.address(this._handle, false)
+    try {
+      this._localAddress = binding.address(this._handle, true)
+    } catch {
+      this._localAddress = null
+    }
+
+    try {
+      this._remoteAddress = binding.address(this._handle, false)
+    } catch {
+      this._remoteAddress = null
+    }
 
     this._state |= constants.state.CONNECTED
     this._continueOpen()


### PR DESCRIPTION
https://github.com/holepunchto/bare-pipe/pull/22 hits it when `accept()`'ing sockets sent over IPC in case the sockets have already closed.