### PR TITLE
Clear BOUND state on server close so listening returns false

### DIFF
--- a/index.js
+++ b/index.js
@@ -731,6 +731,7 @@ exports.Server = class TCPServer extends EventEmitter {
     const err = this._error
 
     this._state &= ~constants.state.BINDING
+    this._state &= ~constants.state.BOUND
     this._error = null
     this._handle = null
     this._address = null

--- a/test.js
+++ b/test.js
@@ -627,6 +627,23 @@ test('socketpair, bidirectional data flow', async (t) => {
   right.write(Buffer.from('from right'))
 })
 
+test('server, listening is false after close', async (t) => {
+  t.plan(3)
+
+  const server = createServer()
+
+  server.listen(0)
+
+  await waitForServer(server)
+
+  t.ok(server.listening, 'listening while bound')
+
+  server.close(() => {
+    t.absent(server.listening, 'not listening after close')
+    t.is(server.address(), null, 'no address after close')
+  })
+})
+
 function waitForServer(server) {
   return new Promise((resolve, reject) => {
     server.on('listening', done).on('error', done)


### PR DESCRIPTION
`server.listening` stayed `true` after a server was closed. Node returns `false`.

`TCPServer._onclose()` cleared the `BINDING` flag but not `BOUND`, and the `listening` getter reads `BOUND`. This also fixes `server.address()` throwing after close (it nulled `_address` while leaving `BOUND` set, skipping the guard that should return `null`).

Fix: clear `BOUND` alongside `BINDING` in `_onclose`.