### PR TITLE
Clear CONNECTING state when a connect attempt fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,6 +199,8 @@ exports.Socket = class TCPSocket extends Duplex {
 
       if (onconnect) this.once('connect', onconnect)
     } catch (err) {
+      this._state &= ~constants.state.CONNECTING
+
       queueMicrotask(() => {
         if (this._pendingOpen) this._pendingOpen(err)
         else this.destroy(err)
@@ -388,6 +390,8 @@ exports.Socket = class TCPSocket extends Duplex {
 
         err = this._errors.length === 1 ? this._errors[0] : new AggregateError(this._errors)
       }
+
+      this._state &= ~constants.state.CONNECTING
 
       if (this._pendingOpen) this._continueOpen(err)
       else this.destroy(err)

--- a/test.js
+++ b/test.js
@@ -79,6 +79,16 @@ test('socket state getters', async (t) => {
   server.close()
 })
 
+test('socket, connecting is false after failed connect', async (t) => {
+  const socket = new Socket()
+  socket.on('error', () => {})
+  socket.connect(1, '127.0.0.1')
+
+  await new Promise((resolve) => socket.on('close', resolve))
+
+  t.absent(socket.connecting, 'not connecting after failed connect')
+})
+
 test('address getters', async (t) => {
   t.plan(14)
 


### PR DESCRIPTION
`socket.connecting` stayed `true` after a failed connect. Node reports `false`.

The success path in `_onconnect` clears `CONNECTING`, but the two failure paths (the give-up branch and the synchronous `binding.connect` catch) called `destroy()` without clearing it, so `connecting` never went back to `false`.

Fix: clear `CONNECTING` on both failure paths, mirroring the success path.